### PR TITLE
Add mockclean utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ test              := .ci/test-cover.sh
 
 install: install-glide
 	( cd linters/badtime ; glide install -v)
+	( cd utilities/mockclean ; glide install -v)
 
 test-internal:
 	@which go-junit-report > /dev/null || go get -u github.com/sectioneight/go-junit-report

--- a/utilities/mockclean/README.md
+++ b/utilities/mockclean/README.md
@@ -1,0 +1,29 @@
+MockClean
+=========
+
+`mockclean` is a utility to address a few shortcomings in `mockgen`. Specifically:
+
+- Remove self referential imports;
+- Offers determinism when import aliasing;
+- Grouping imports into chunks based on prefixes;
+
+## Installation
+
+```sh
+go get -u github.com/m3db/build-tools/utilities/mockclean
+```
+
+## Usage
+
+The following command orders the imports into three chunks: stdlib, those starting with "github.com/some", and third-party; and aliases them deterministically; and removes any imports from the same package.
+
+```sh
+mockgen -package=abc github.com/some/path/abc IFace0 \
+ | mockclean -cleanup-selfref -cleanup-import -prefixes "github.com/some" -pkg github.com/some/path/abc -out $GOPATH/src/github.com/some/path/abc/abc_mock.go
+```
+
+You can embed this inside a `go:generate` command, as follows:
+
+```go
+//go:generate sh -c "mockgen -package=abc github.com/some/path/abc IFace0 | mockclean ..."
+```

--- a/utilities/mockclean/glide.lock
+++ b/utilities/mockclean/glide.lock
@@ -1,0 +1,25 @@
+hash: 49274365be70133dea086c6e357dc71d3c624fe92cd3dc47e36a19c6fa68dd1d
+updated: 2018-02-12T11:58:12.065379578-05:00
+imports:
+- name: github.com/m3db/m3x
+  version: dbdbd564ff2f64388a641ce61f541eceb7d2e416
+  subpackages:
+  - log
+- name: golang.org/x/tools
+  version: 95b47aa5df4eda9bfbc0133f77c0e320f0275eba
+  subpackages:
+  - go/ast/astutil
+testImports:
+- name: github.com/davecgh/go-spew
+  version: adab96458c51a58dc1783b3335dcce5461522e75
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  subpackages:
+  - assert
+  - require

--- a/utilities/mockclean/glide.yaml
+++ b/utilities/mockclean/glide.yaml
@@ -1,0 +1,15 @@
+package: github.com/m3db/build-tools/utilities/mockclean
+import:
+- package: github.com/m3db/m3x
+  version: dbdbd564ff2f64388a641ce61f541eceb7d2e416
+  subpackages:
+  - log
+- package: golang.org/x/tools
+  version: 95b47aa5df4eda9bfbc0133f77c0e320f0275eba
+  subpackages:
+  - go/ast/astutil
+testImport:
+- package: github.com/stretchr/testify
+  version: ^1.2.1
+  subpackages:
+  - require

--- a/utilities/mockclean/main.go
+++ b/utilities/mockclean/main.go
@@ -1,0 +1,414 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	xlog "github.com/m3db/m3x/log"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+var (
+	pkg            = flag.String("pkg", "", "package mock is being generated for")
+	in             = flag.String("in", defaultInputStdin, "input path for mock being read, '-' for stdin")
+	out            = flag.String("out", "", "file path for mock being written")
+	perm           = flag.String("perm", "666", "permissions to write file with")
+	groupPrefixes  = flag.String("prefixes", defaultGroupPrefixes, "prefixes to group imports by")
+	selfRefCleanup = flag.Bool("cleanup-selfref", false, "cleanup self referrential imports")
+	importCleanup  = flag.Bool("cleanup-import", false, "cleanup import aliasing and ordering")
+)
+
+const (
+	defaultInputStdin    = "-"
+	defaultGroupPrefixes = "github.com/m3db"
+)
+
+func main() {
+	logger, err := xlog.Configuration{}.BuildLogger()
+	if err != nil {
+		log.Fatalf("unable to build logger: %v", err)
+	}
+
+	flag.Parse()
+
+	newFileMode, err := parseNewFileMode(*perm)
+	if err != nil {
+		logger.Errorf("perm: %v", err)
+	}
+
+	if len(*pkg) == 0 || len(*in) == 0 || len(*out) == 0 || err != nil {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	var inputData []byte
+	if *in == defaultInputStdin {
+		inputData, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		inputData, err = ioutil.ReadFile(*out)
+	}
+	if err != nil {
+		logger.Fatalf("unable to read input: %v", err)
+	}
+
+	if *selfRefCleanup {
+		basePkg := extractBasePkg(*pkg)
+		replacer := strings.NewReplacer(
+			// Replace any self referential imports
+			fmt.Sprintf("%s \"%s\"", basePkg, *pkg), "",
+			fmt.Sprintf("%s.", basePkg), "")
+		inputData = []byte(replacer.Replace(string(inputData)))
+	}
+
+	if *importCleanup {
+		inputData, err = cleanupImports(inputData)
+		if err != nil {
+			logger.Fatalf("unable to cleanup imports: %v", err)
+		}
+
+		prefixes := strings.Fields(*groupPrefixes)
+		inputData, err = reorderImports(inputData, prefixes)
+		if err != nil {
+			logger.Fatalf("unable to reorder imports: %v", err)
+		}
+	}
+
+	err = ioutil.WriteFile(*out, inputData, newFileMode)
+	if err != nil {
+		logger.Fatalf("unable to write output to %s: %v", *out, err)
+	}
+}
+
+// reorderImports re-orders imports into groups following the convention below:
+// import (
+// 	 stdlib
+//
+//   userPrefixes[0]
+//   ...
+//   userPrefixes[n]
+//
+//   third-party
+//  )
+func reorderImports(src []byte, userPrefixes []string) ([]byte, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// extract the import into required groups
+	standardLibImports := []ast.ImportSpec{}
+	thirdPartyImports := []ast.ImportSpec{}
+	userPrefixImports := make(map[string][]ast.ImportSpec)
+	for _, im := range file.Imports {
+		if isStdlibPackage(im.Path.Value) {
+			standardLibImports = append(standardLibImports, *im)
+			continue
+		}
+
+		userImport := false
+		for _, pre := range userPrefixes {
+			if strings.Contains(im.Path.Value, pre) {
+				userPrefixImports[pre] = append(userPrefixImports[pre], *im)
+				userImport = true
+				break
+			}
+		}
+
+		// default to third-party import if others are not found
+		if !userImport {
+			thirdPartyImports = append(thirdPartyImports, *im)
+		}
+	}
+
+	// sort all the imports
+	sort.Sort(importSpecs(standardLibImports))
+	sort.Sort(importSpecs(thirdPartyImports))
+	for _, im := range userPrefixImports {
+		sort.Sort(importSpecs(im))
+	}
+
+	// now we can replace all the import statements in the original source with
+	// new single import block and associated decls.
+	removeExistingImports := func(c *astutil.Cursor) bool {
+		node := c.Node()
+		decl, ok := node.(*ast.GenDecl)
+		if !ok {
+			return true
+		}
+
+		if decl.Tok != token.IMPORT {
+			return true
+		}
+
+		c.Delete()
+		return false
+	}
+	cleaned := astutil.Apply(file, removeExistingImports, nil)
+
+	// convert import decls into correct structure
+	generateImports := func(packagePos token.Pos) []byte {
+		var buff bytes.Buffer
+		buff.WriteString("import (\n")
+		insertNewLineBeforeUsage := false
+		writeImport := func(im ast.ImportSpec) {
+			insertNewLineBeforeUsage = true
+			if im.Name != nil {
+				buff.WriteString(fmt.Sprintf("\t%s %s\n", im.Name.Name, im.Path.Value))
+			} else {
+				buff.WriteString(fmt.Sprintf("\t%s\n", im.Path.Value))
+			}
+		}
+		for _, im := range standardLibImports {
+			writeImport(im)
+		}
+
+		for _, pre := range userPrefixes {
+			imports := userPrefixImports[pre]
+			if len(imports) > 0 && insertNewLineBeforeUsage {
+				buff.WriteString("\n")
+				insertNewLineBeforeUsage = false
+			}
+			for _, im := range userPrefixImports[pre] {
+				writeImport(im)
+			}
+		}
+		if len(thirdPartyImports) > 0 && insertNewLineBeforeUsage {
+			buff.WriteString("\n")
+		}
+		for _, im := range thirdPartyImports {
+			writeImport(im)
+		}
+		buff.WriteString(")")
+
+		return buff.Bytes()
+	}
+
+	newImports := generateImports(file.Package)
+	cleanedFile := cleaned.(*ast.File)
+
+	var buf bytes.Buffer
+	format.Node(&buf, fset, cleanedFile)
+	re := regexp.MustCompile("package .*")
+	cleanedWithImports := re.ReplaceAllStringFunc(buf.String(), func(x string) string {
+		return fmt.Sprintf("%s\n\n%s", x, newImports)
+	})
+	return []byte(cleanedWithImports), nil
+}
+
+// cleanupImports makes the following changes:
+// - if an import has the same alias as it's base package, it removes the alias
+// 	 i.e. converts "import x abc/x" ==> "import abc/x"
+// - if two packages share the same base package name, it prefers to alias the non-standard lib
+//   i.e. it converts
+// import (
+//   fmt "x/fmt"
+//   fmt0 "fmt"
+// )
+// into
+// import (
+//   "fmt"
+//   fmt0 "x/fmt"
+// )
+func cleanupImports(src []byte) ([]byte, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// basePkg -> []importStmt
+	importMap := make(map[string][]ast.ImportSpec)
+	for _, i := range file.Imports {
+		base, err := strconv.Unquote(i.Path.Value)
+		if err != nil {
+			panic(err)
+		}
+		basePkg := extractBasePkg(base)
+		arr, ok := importMap[basePkg]
+		if !ok {
+			importMap[basePkg] = []ast.ImportSpec{*i}
+		} else {
+			importMap[basePkg] = append(arr, *i)
+		}
+	}
+
+	// track all import alias changes
+	var swaps swapIdents
+
+	// rewrite the ast for each import that has an issue
+	for basePkg, imports := range importMap {
+		// can never have len(imports) == 0, asserting that to be sure
+		if len(imports) == 0 {
+			return nil, fmt.Errorf("illegal internal state: %+v", importMap)
+		}
+
+		// i.e. we only have a single import with this basePkg, and we're still aliasing it
+		// can just drop the alias in this case
+		if len(imports) == 1 && imports[0].Name != nil && imports[0].Name.Name == basePkg {
+			path := mustUnquote(imports[0].Path.Value)
+			astutil.DeleteNamedImport(fset, file, basePkg, path)
+			astutil.AddImport(fset, file, path)
+			continue
+		}
+
+		// i.e. we have >= 2 imports with the same basePkg. need to ensure that the standard
+		// library version has no alias.
+		var (
+			stdLibImport, otherPackageWithBaseAlias *ast.ImportSpec
+			redundantAlias                          = false
+		)
+		for _, im := range imports {
+			im := im
+			// i.e. stdlib package has a redundant alias
+			if isStdlibPackage(im.Path.Value) && im.Name != nil && im.Name.Name == basePkg {
+				astutil.DeleteNamedImport(fset, file, basePkg, mustUnquote(im.Path.Value))
+				astutil.AddImport(fset, file, mustUnquote(im.Path.Value))
+				redundantAlias = true
+				break
+			}
+			// i.e. stdlib has an extra alias
+			if isStdlibPackage(im.Path.Value) && im.Name != nil && im.Name.Name != basePkg {
+				stdLibImport = &im
+				continue
+			}
+			if im.Name != nil && im.Name.Name == basePkg {
+				otherPackageWithBaseAlias = &im
+				continue
+			}
+		}
+		if redundantAlias || stdLibImport == nil || otherPackageWithBaseAlias == nil {
+			continue
+		}
+		astutil.DeleteNamedImport(fset, file, stdLibImport.Name.Name, mustUnquote(stdLibImport.Path.Value))
+		astutil.DeleteNamedImport(fset, file, basePkg, mustUnquote(otherPackageWithBaseAlias.Path.Value))
+		astutil.AddImport(fset, file, mustUnquote(stdLibImport.Path.Value))
+		astutil.AddNamedImport(
+			fset, file, stdLibImport.Name.Name, mustUnquote(otherPackageWithBaseAlias.Path.Value))
+		swaps = append(swaps, swapIdent{
+			x: stdLibImport.Name.Name,
+			y: basePkg,
+		})
+	}
+
+	// print current state of file, with new imports
+	var buf bytes.Buffer
+	printer.Fprint(&buf, fset, file)
+
+	// perform all import alias changes
+	bytes := swaps.re().ReplaceAllFunc(buf.Bytes(), func(input []byte) []byte {
+		padded := func(x string) string { return fmt.Sprintf("%s.", x) }
+		str := string(input)
+		for _, s := range swaps {
+			if padded(s.x) == str {
+				return []byte(padded(s.y))
+			} else if padded(s.y) == str {
+				return []byte(padded(s.x))
+			}
+		}
+		return input
+	})
+	return bytes, nil
+}
+
+func mustUnquote(s string) string {
+	o, err := strconv.Unquote(s)
+	if err != nil {
+		panic(err)
+	}
+	return o
+}
+
+func isThirdParty(importPath string) bool {
+	// Third party package import path usually contains "." (".com", ".org", ...)
+	// This logic is taken from golang.org/x/tools/imports package.
+	return strings.Contains(importPath, ".")
+}
+
+func isStdlibPackage(importPath string) bool {
+	return !isThirdParty(importPath)
+}
+
+func extractBasePkg(s string) string {
+	pkgParts := strings.Split(s, "/")
+	return pkgParts[len(pkgParts)-1]
+}
+
+func parseNewFileMode(str string) (os.FileMode, error) {
+	if len(str) != 3 {
+		return 0, fmt.Errorf("file mode must be 3 chars long")
+	}
+
+	str = "0" + str
+
+	var v uint32
+	n, err := fmt.Sscanf(str, "%o", &v)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse: %v", err)
+	}
+	if n != 1 {
+		return 0, fmt.Errorf("no value to parse")
+	}
+	return os.FileMode(v), nil
+}
+
+type swapIdent struct {
+	x string
+	y string
+}
+
+func (s swapIdent) re() string {
+	return fmt.Sprintf("%s|%s", s.x, s.y)
+}
+
+type swapIdents []swapIdent
+
+func (si swapIdents) re() *regexp.Regexp {
+	strs := make([]string, 0, len(si))
+	for _, s := range si {
+		strs = append(strs, s.re())
+	}
+	chars := strings.Join(strs, "|")
+	base := fmt.Sprintf(`\b(%s)\.`, chars)
+	return regexp.MustCompile(base)
+}
+
+type importSpecs []ast.ImportSpec
+
+func (a importSpecs) Len() int           { return len(a) }
+func (a importSpecs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a importSpecs) Less(i, j int) bool { return a[i].Path.Value < a[j].Path.Value }

--- a/utilities/mockclean/order_test.go
+++ b/utilities/mockclean/order_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testCase struct {
+	input  string
+	output string
+}
+
+func filePath(n int, suffix string) string {
+	return fmt.Sprintf("testdata/order/example_%d.go.%s", n, suffix)
+}
+
+func newTestCase(n int) testCase {
+	return testCase{
+		input:  filePath(n, "input"),
+		output: filePath(n, "output"),
+	}
+}
+
+func TestOrderExample(t *testing.T) {
+	testCases := []testCase{
+		newTestCase(1),
+		newTestCase(2),
+		newTestCase(3),
+		newTestCase(4),
+	}
+	for _, tc := range testCases {
+		bytes, err := ioutil.ReadFile(tc.input)
+		require.NoError(t, err, "", tc)
+
+		expected, err := ioutil.ReadFile(tc.output)
+		require.NoError(t, err, "", tc)
+
+		obs, err := reorderImports(bytes, strings.Fields(defaultGroupPrefixes))
+		require.NoError(t, err)
+
+		e := strings.Trim(string(expected), " \t\n")
+		o := strings.Trim(string(obs), " \n\t")
+		require.True(t, e == o,
+			fmt.Sprintf("expected: [%s]\n observed: [%s]\n", e, o), tc)
+	}
+}

--- a/utilities/mockclean/renaming_test.go
+++ b/utilities/mockclean/renaming_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func renameFilePath(n int, suffix string) string {
+	return fmt.Sprintf("testdata/renaming/example_%d.go.%s", n, suffix)
+}
+
+func newRenamingTestCase(n int) testCase {
+	return testCase{
+		input:  renameFilePath(n, "input"),
+		output: renameFilePath(n, "output"),
+	}
+}
+
+func TestRenamingExamples(t *testing.T) {
+	testCases := []testCase{
+		newRenamingTestCase(1),
+		newRenamingTestCase(2),
+	}
+	for _, tc := range testCases {
+		bytes, err := ioutil.ReadFile(tc.input)
+		require.NoError(t, err, "", tc)
+
+		expected, err := ioutil.ReadFile(tc.output)
+		require.NoError(t, err, "", tc)
+
+		obs, err := cleanupImports(bytes)
+		require.NoError(t, err)
+
+		e := strings.Trim(string(expected), " \t\n")
+		o := strings.Trim(string(obs), " \n\t")
+		require.True(t, e == o,
+			fmt.Sprintf("expected: [%s]\n observed: [%s]\n", e, o), tc)
+	}
+}

--- a/utilities/mockclean/testdata/order/example_1.go.input
+++ b/utilities/mockclean/testdata/order/example_1.go.input
@@ -1,0 +1,10 @@
+package main
+
+import (
+  _ "github.com/m3db/m3db"
+  "fmt"
+)
+
+func main() {
+  fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_1.go.output
+++ b/utilities/mockclean/testdata/order/example_1.go.output
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	_ "github.com/m3db/m3db"
+)
+
+func main() {
+	fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_2.go.input
+++ b/utilities/mockclean/testdata/order/example_2.go.input
@@ -1,0 +1,12 @@
+package main
+
+import (
+  "fmt"
+
+  _ "github.com/m3db/m3db"
+  "io/ioutil"
+)
+
+func main() {
+  fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_2.go.output
+++ b/utilities/mockclean/testdata/order/example_2.go.output
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	_ "github.com/m3db/m3db"
+)
+
+func main() {
+	fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_3.go.input
+++ b/utilities/mockclean/testdata/order/example_3.go.input
@@ -1,0 +1,11 @@
+package main
+
+import (
+  "fmt"
+  _ "github.com/m3db/m3db"
+  "golang.org/x/net/context"
+)
+
+func main() {
+  fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_3.go.output
+++ b/utilities/mockclean/testdata/order/example_3.go.output
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+
+	_ "github.com/m3db/m3db"
+
+	"golang.org/x/net/context"
+)
+
+func main() {
+	fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_4.go.input
+++ b/utilities/mockclean/testdata/order/example_4.go.input
@@ -1,0 +1,10 @@
+package main
+
+import (
+  _ "io/ioutil"
+  "fmt"
+)
+
+func main() {
+  fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/order/example_4.go.output
+++ b/utilities/mockclean/testdata/order/example_4.go.output
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	_ "io/ioutil"
+)
+
+func main() {
+	fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/renaming/example_1.go.input
+++ b/utilities/mockclean/testdata/renaming/example_1.go.input
@@ -1,0 +1,9 @@
+package main
+
+import (
+  fmt "fmt"
+)
+
+func main() {
+  fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/renaming/example_1.go.output
+++ b/utilities/mockclean/testdata/renaming/example_1.go.output
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("here")
+}

--- a/utilities/mockclean/testdata/renaming/example_2.go.input
+++ b/utilities/mockclean/testdata/renaming/example_2.go.input
@@ -1,0 +1,11 @@
+package main
+
+import (
+  fmt0 "fmt"
+  fmt "github.com/m3db/m3x/fmt"
+)
+
+func main() {
+  fmt.Println("m3x fmt")
+  fmt0.Println("stdlib fmt")
+}

--- a/utilities/mockclean/testdata/renaming/example_2.go.output
+++ b/utilities/mockclean/testdata/renaming/example_2.go.output
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	fmt0 "github.com/m3db/m3x/fmt"
+)
+
+func main() {
+	fmt0.Println("m3x fmt")
+	fmt.Println("stdlib fmt")
+}


### PR DESCRIPTION
This PR introduces a new utility for helping make mockgen idempotent. It migrates https://github.com/m3db/m3db/blob/master/generated/mocks/writer/writer_main.go and ports the script from https://github.com/m3db/ci-scripts/pull/29 

/cc @robskillington 

