### PR TITLE
Revert "skip bad file errors (#15)"

### DIFF
--- a/linters/badtime/main.go
+++ b/linters/badtime/main.go
@@ -94,9 +94,6 @@ func handleImportPaths(
 	conf := loader.Config{
 		Fset:  fs,
 		Build: &ctx,
-		TypeChecker: types.Config{
-			Error: func(e error) {},
-		},
 		// Continue even if type or IO errors are present
 		AllowErrors: true,
 	}


### PR DESCRIPTION
Reverting the previous error check diff since we are seeing the error with other linters as well. It seems to be an environment issue and not anything particular to badtime. 