### PR TITLE
[WIP] Add tool to find changed packages

### DIFF
--- a/utilities/diffdep/git.go
+++ b/utilities/diffdep/git.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"log"
+	"path/filepath"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+func findChangedDirs(ctx *build.Context, rootDir, baseBranch string) (map[string]struct{}, error) {
+	path := filepath.Join(ctx.GOPATH, "src", rootDir)
+	repo, err := git.PlainOpen(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open git repository in '%v': %v", path, err)
+	}
+
+	headTree, err := getTree(repo, plumbing.HEAD.Short())
+	if err != nil {
+		return nil, err
+	}
+
+	baseTree, err := getTree(repo, baseBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	diff, err := baseTree.Diff(headTree)
+	if err != nil {
+		return nil, fmt.Errorf("could not calculate diff between HEAD and branch '%v': %v", baseBranch, err)
+	}
+
+	changed := make(map[string]struct{})
+	for _, change := range diff {
+		maybeAddDir(changed, rootDir, change.From.Name)
+		maybeAddDir(changed, rootDir, change.To.Name)
+	}
+
+	return changed, nil
+}
+
+func getTree(repo *git.Repository, branch string) (*object.Tree, error) {
+	hash, err := repo.ResolveRevision(plumbing.Revision(branch))
+	if err != nil {
+		log.Fatalf("could not get SHA for branch '%v': %v", branch, err)
+	}
+
+	obj, err := repo.Object(plumbing.AnyObject, *hash)
+	if err != nil {
+		return nil, fmt.Errorf("could not get git object for branch '%v': %v", branch, err)
+	}
+
+	commit, ok := obj.(*object.Commit)
+	if !ok {
+		return nil, fmt.Errorf("unexpected typo of object, found %T, want *object.Commit", obj)
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("could not get tree for branch '%v': %v", branch, err)
+	}
+
+	return tree, nil
+}
+
+func maybeAddDir(dirs map[string]struct{}, rootDir, file string) {
+	// Get the directory of the file by prepending the root directory, removing the
+	// filename, and stripping the trailing slash.
+	dir, _ := filepath.Split(filepath.Join(rootDir, file))
+	dirs[filepath.Clean(dir)] = struct{}{}
+}

--- a/utilities/diffdep/glide.lock
+++ b/utilities/diffdep/glide.lock
@@ -1,0 +1,121 @@
+hash: 8cbfe6b43da9ded8044ab3a69cb3eaa37865a28a3a59ca9653bd7a11ea822955
+updated: 2018-04-08T21:54:00.453096-04:00
+imports:
+- name: github.com/emirpasic/gods
+  version: b2394dfbb6314eeb616db55d1e01928f287da4b4
+  subpackages:
+  - containers
+  - lists
+  - lists/arraylist
+  - trees
+  - trees/binaryheap
+  - utils
+- name: github.com/jbenet/go-context
+  version: d14ea06fba99483203c19d92cfcd13ebe73135f4
+  subpackages:
+  - io
+- name: github.com/kevinburke/ssh_config
+  version: 6c3af74fa5b59d325e597106f6ef94b9b413685c
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+- name: github.com/pelletier/go-buffruneio
+  version: e2f66f8164ca709d4c21e815860afd2024e9b894
+- name: github.com/sergi/go-diff
+  version: feef008d51ad2b3778f85d387ccf91735543008d
+  subpackages:
+  - diffmatchpatch
+- name: github.com/src-d/gcfg
+  version: f187355171c936ac84a82793659ebb4936bc1c23
+  subpackages:
+  - scanner
+  - token
+  - types
+- name: github.com/xanzy/ssh-agent
+  version: ba9c9e33906f58169366275e3450db66139a31a9
+- name: golang.org/x/crypto
+  version: 6914964337150723782436d56b3f21610a74ce7b
+  subpackages:
+  - cast5
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - openpgp
+  - openpgp/armor
+  - openpgp/elgamal
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
+  - ssh
+  - ssh/agent
+  - ssh/knownhosts
+- name: golang.org/x/net
+  version: ab5485076ff3407ad2d02db054635913f017b0ed
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: f6cff0780e542efa0c8e864dc8fa522808f6a598
+  subpackages:
+  - windows
+- name: golang.org/x/text
+  version: 4ee4af566555f5fbe026368b75596286a312663a
+  subpackages:
+  - transform
+  - unicode/norm
+- name: golang.org/x/tools
+  version: ac136b6c2db7c4d43955e4bc7174db36dc0539c0
+  subpackages:
+  - buildutil
+  - go/buildutil
+  - refactor/importgraph
+- name: gopkg.in/src-d/go-billy.v4
+  version: df053870ae7070b0350624ba5a22161ba3796cc0
+  subpackages:
+  - helper/chroot
+  - helper/polyfill
+  - osfs
+  - util
+- name: gopkg.in/src-d/go-git.v4
+  version: 247cf690745dfd67ccd9f0c07878e6dd85e6c9ed
+  subpackages:
+  - config
+  - internal/revision
+  - plumbing
+  - plumbing/cache
+  - plumbing/filemode
+  - plumbing/format/config
+  - plumbing/format/diff
+  - plumbing/format/gitignore
+  - plumbing/format/idxfile
+  - plumbing/format/index
+  - plumbing/format/objfile
+  - plumbing/format/packfile
+  - plumbing/format/pktline
+  - plumbing/object
+  - plumbing/protocol/packp
+  - plumbing/protocol/packp/capability
+  - plumbing/protocol/packp/sideband
+  - plumbing/revlist
+  - plumbing/storer
+  - plumbing/transport
+  - plumbing/transport/client
+  - plumbing/transport/file
+  - plumbing/transport/git
+  - plumbing/transport/http
+  - plumbing/transport/internal/common
+  - plumbing/transport/server
+  - plumbing/transport/ssh
+  - storage
+  - storage/filesystem
+  - storage/filesystem/internal/dotgit
+  - storage/memory
+  - utils/binary
+  - utils/diff
+  - utils/ioutil
+  - utils/merkletrie
+  - utils/merkletrie/filesystem
+  - utils/merkletrie/index
+  - utils/merkletrie/internal/frame
+  - utils/merkletrie/noder
+- name: gopkg.in/warnings.v0
+  version: ec4a0fea49c7b46c2aeb0b51aac55779c607e52b
+testImports: []

--- a/utilities/diffdep/glide.yaml
+++ b/utilities/diffdep/glide.yaml
@@ -1,0 +1,10 @@
+package: github.com/m3db/build-tools/utilities/diffdep
+import:
+- package: golang.org/x/tools
+  version: master
+  subpackages:
+  - buildutil
+  - refactor/importgraph
+- package: gopkg.in/src-d/go-git.v4
+  version: ^4.0.0
+

--- a/utilities/diffdep/graph.go
+++ b/utilities/diffdep/graph.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/build"
+)
+
+type graph map[string]map[string]struct{}
+
+func newGraph(ctx *build.Context, pkgs map[string]bool) (graph, error) {
+	g := make(graph, len(pkgs))
+
+	for pkg := range pkgs {
+		buildPkg, err := ctx.Import(pkg, "", 0)
+		if err != nil {
+			if _, ok := err.(*build.NoGoError); ok {
+				// The package doesn't contain any buildable go files. This can be caused, for
+				// example, when the only go files in a package contain build flags which are
+				// not present in our build context.
+				continue
+			}
+			return nil, fmt.Errorf("could not import package %v: %v", pkg, err)
+		}
+
+		visited := make(map[string]string)
+
+		for _, path := range buildPkg.Imports {
+			g.maybeAddEdge(ctx, buildPkg, visited, pkg, path)
+		}
+		for _, path := range buildPkg.TestImports {
+			g.maybeAddEdge(ctx, buildPkg, visited, pkg, path)
+		}
+		for _, path := range buildPkg.XTestImports {
+			g.maybeAddEdge(ctx, buildPkg, visited, pkg, path)
+		}
+	}
+
+	return g, nil
+}
+
+func (g graph) maybeAddEdge(
+	ctx *build.Context, buildPkg *build.Package, visited map[string]string, pkg, path string,
+) {
+	if path == "C" {
+		// Not a real package.
+		return
+	}
+
+	importedPkg, ok := visited[path]
+	if !ok {
+		// It's okay for Import to return an error as not all packages that can be found in
+		// a package will necessarily be present. For example, packages imported only by test
+		// files in vendored packages will not be installed. In the case of an error, Import
+		// always returns a non-nil *Package. In the case of an error it will only contain
+		// partial information.
+		importBuildPkg, _ := ctx.Import(path, buildPkg.Dir, build.FindOnly)
+		if importBuildPkg != nil {
+			importedPkg = importBuildPkg.ImportPath
+		} else {
+			importedPkg = path
+		}
+		visited[path] = importedPkg
+		g.addEdge(importedPkg, pkg)
+	}
+}
+
+func (g graph) addEdge(from, to string) {
+	edges, ok := g[from]
+	if !ok {
+		edges = make(map[string]struct{})
+		g[from] = edges
+	}
+	edges[to] = struct{}{}
+}
+
+func (g graph) walk(node string, visited map[string]struct{}) error {
+	if _, ok := visited[node]; ok {
+		return nil
+	}
+	visited[node] = struct{}{}
+	edges, ok := g[node]
+	if !ok {
+		return fmt.Errorf("could not find node '%s' in graph", node)
+	}
+	for to := range edges {
+		if err := g.walk(to, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/utilities/diffdep/main.go
+++ b/utilities/diffdep/main.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/build"
+	"log"
+	"strings"
+
+	"golang.org/x/tools/go/buildutil"
+)
+
+func main() {
+	var (
+		branch string
+	)
+	flag.StringVar(&branch, "branch", "master", "the base branch to compare against to find changed files")
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		log.Fatal("TODO")
+	}
+	repo := flag.Args()[0]
+
+	ctx := build.Default
+
+	changedDirs, err := findChangedDirs(&ctx, repo, branch)
+	if err != nil {
+		log.Fatalf("unable to find changed directories: %v", err)
+	}
+	if len(changedDirs) == 0 {
+		return
+	}
+
+	pkgs := buildutil.ExpandPatterns(&ctx, []string{repo + "/..."})
+	graph, err := newGraph(&ctx, pkgs)
+	if err != nil {
+		log.Fatalf("unable to build dependency graph: %v", err)
+	}
+
+	seen := make(map[string]struct{})
+	for dir := range changedDirs {
+		if _, ok := pkgs[dir]; !ok {
+			continue
+		}
+		graph.walk(dir, seen)
+	}
+
+	for pkg := range seen {
+		if !strings.Contains(pkg, "/vendor/") {
+			fmt.Println(pkg)
+		}
+	}
+}


### PR DESCRIPTION
This diff adds a tool `diffDep` (short for diff with dependencies) for finding the packages which have changed in a git branch along with their dependencies. Such a tool could be used as part of a larger build chain so that tests and lints only need to be run against packages which may have been affected by the changes in a branch.